### PR TITLE
Remove SELinux override

### DIFF
--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -4,7 +4,7 @@ base_ntp_package_name: "ntp"
 
 base_disable_firewalld: True
 
-base_disable_selinux: True
+base_disable_selinux: False
 
 base_firewalld_bin_path: /usr/sbin/firewalld
 


### PR DESCRIPTION
# Issue
Variables in `redhat.yml` cannot be overriden from outside-playbook.

AMI tested with: Amazon AWS AMI (2017.09)

My vars file:
```yaml
# role: ansible-role-base
base_disable_selinux: False
```

# Behaviour:
```
amazon-ebs: TASK [ansible-role-base : Disable SELinux in the configuration file] ***********
amazon-ebs: fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Destination /etc/sysconfig/selinux does not exist !", "rc": 257}
amazon-ebs: 	to retry, use: --limit @/tmp/packer-provisioner-ansible-local/59edb7b9-de01-a497-f2b3-770885e633f8/jenkins-slave.retry
```

# Code snippet causing this:

```yaml
- name: Disable SELinux in the configuration file
  lineinfile:
    dest: /etc/sysconfig/selinux
    regexp: '^(#)?SELINUX='
    line: 'SELINUX=disabled'
    state: present
  register: selinux_status
  when: base_disable_selinux
```
